### PR TITLE
Potential fix for code scanning alert no. 2: SQL query built from user-controlled sources

### DIFF
--- a/server/routes.py
+++ b/server/routes.py
@@ -18,8 +18,9 @@ def index():
         books = [Book(*row) for row in cursor]
 
     elif author:
+        pattern = f"%{author}%"
         cursor.execute(
-            "SELECT * FROM books WHERE author LIKE '%" + author + "%'"
+            "SELECT * FROM books WHERE author LIKE %s", (pattern,)
         )
         books = [Book(*row) for row in cursor]
 


### PR DESCRIPTION
Potential fix for [https://github.com/hemanthbattala10-droid/skills-introduction-to-codeql/security/code-scanning/2](https://github.com/hemanthbattala10-droid/skills-introduction-to-codeql/security/code-scanning/2)

To fix the issue, the code must use query parameterization rather than directly embedding user input in the SQL string. Most Python database connectors (including the standard DB-API interface used by many) support parameterized queries using placeholders (`%s`) for arguments. For LIKE queries with `%`, the pattern string (including `%`) should be passed in as a parameter. 

**Steps:**
- Refactor the code to construct the pattern string (e.g., `f"%{author}%"`) in Python, not in the SQL statement, and pass it as a parameter.
- Change the SQL query string to use a placeholder instead of string concatenation.
- Pass the pattern string in a tuple or sequence as the second argument of `cursor.execute`.

**Location:** On line 22 in `server/routes.py`. It is also good practice to ensure similar changes elsewhere if more vulnerabilities exist, but per instructions, only line 22 (the concrete error) will be changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
